### PR TITLE
Bundle teleco_daisy v0.2.2, add climate platform, fix config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,65 @@
-# # Home Assistant Teleco Daisy box integration
+# Home Assistant Teleco Daisy Integration
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=andreasnuesslein&repository=hass_teleco_daisy&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=claesmathias&repository=hass_teleco_daisy&category=integration)
 
-Home Assistant custom component for Teleco Automation Daisy
+Home Assistant custom component for Teleco Automation / TMate Daisy smart home devices.
+
+## Supported devices
+
+| Device | HA platform | Type | Model |
+|---|---|---|---|
+| White light (4-level) | `light` | 21 | 17, 34 |
+| RGB light | `light` | 23 | 32 |
+| 4-channel heater | `climate` | 21 | 20 |
+| Slats cover (venetian blind) | `cover` | 24 | 27 |
+| Retractable slats cover | `cover` | 24 | 44 |
+| Shade / screen cover | `cover` | 22 | 25, 31 |
+| Awning cover | `cover` | 22 | 21 |
+
+Any device that does not match a known type/model is loaded as a generic device and will not appear in Home Assistant. A warning is logged with its type and model numbers — please open an issue if you have an unsupported device.
 
 ## Installation
 
-1. Copy `custom_components/hass_teleco_daisy` directory into your `custom_components` in your configuration directory.
-2. Restart Home Assistant
-3. Open `Settings -> Devices & Services -> Integration`
-4. Search for `Teleco Daisy` and click the search result
-5. Configure login credentials and click `Submit`
+### Via HACS (recommended)
+
+1. Add this repository to HACS as a custom repository (Integration category).
+2. Install **Teleco Daisy** from HACS.
+3. Restart Home Assistant.
+4. Go to **Settings → Devices & Services → Add Integration**.
+5. Search for `Teleco Daisy`, enter your credentials and click **Submit**.
+
+### Manual
+
+1. Copy the `custom_components/teleco_daisy` directory into your `<config>/custom_components/` folder.
+2. Restart Home Assistant.
+3. Follow steps 4–5 above.
+
+## Notes
+
+- The integration polls all devices every 15 seconds.
+- The Teleco cloud API is required; local-only operation is not supported.
+- The `teleco-daisy` library is bundled inside the component, so no extra pip install is needed.
+
+## Changelog
+
+### 0.2.3
+
+- **Bundled library** — the `teleco-daisy` API client is now included directly in the component. No PyPI dependency required; the integration installs cleanly on any HA instance via HACS.
+- **Retractable slats cover** (type 24, model 44) — new device class. Command IDs are fetched dynamically from the API on first use.
+- **Shade/screen cover state fix** — shades now correctly report as *open* when retracted. Teleco's API uses inverted semantics (`OPEN` = deployed, `CLOSE` = retracted); the mapping to HA `is_closed` is now correct.
+- **Climate platform** — heater (type 21, model 20) is now exposed as a `climate` entity with HEAT/OFF modes and 50/75/100 % power presets.
+- **Config flow fix** — added missing `strings.json`; the setup dialog no longer returns a 500 error.
+
+### 0.1.12
+
+- Added `DaisyAwningCover` (type 22, model 21).
+
+### 0.1.10
+
+- Added `DaisyWhite4LevelLight` (replaces `DaisyWhiteLight`).
+- Fixed LED on/off for type 21 model 17.
+- Fixed light brightness status update.
+
+### 0.1.5
+
+- Added 4-channel heater (type 21, model 20).

--- a/custom_components/teleco_daisy/__init__.py
+++ b/custom_components/teleco_daisy/__init__.py
@@ -13,19 +13,30 @@ PLATFORMS: list[str] = ["light", "cover", "climate"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    _LOGGER.debug("async_setup_entry: setting up entry '%s'", entry.title)
+
     daisy_hub = DaisyHub(hass, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
+
+    _LOGGER.debug("async_setup_entry: logging in as %s", entry.data[CONF_USERNAME])
     await hass.async_add_executor_job(daisy_hub.login)
+    _LOGGER.debug("async_setup_entry: login successful, fetching entities")
+
     await hass.async_add_executor_job(daisy_hub.fetch_entities)
+    _LOGGER.debug("async_setup_entry: entities fetched, forwarding to platforms")
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = daisy_hub
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.debug("async_setup_entry: platforms set up successfully")
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    _LOGGER.debug("async_unload_entry: unloading entry '%s'", entry.title)
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
-
+        _LOGGER.debug("async_unload_entry: entry '%s' unloaded", entry.title)
+    else:
+        _LOGGER.warning("async_unload_entry: failed to unload entry '%s'", entry.title)
     return unload_ok

--- a/custom_components/teleco_daisy/__init__.py
+++ b/custom_components/teleco_daisy/__init__.py
@@ -9,7 +9,7 @@ from .hub import DaisyHub
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["light", "cover"]
+PLATFORMS: list[str] = ["light", "cover", "climate"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/teleco_daisy/_lib/__init__.py
+++ b/custom_components/teleco_daisy/_lib/__init__.py
@@ -1,0 +1,85 @@
+"""
+teleco_daisy
+~~~~~~~~~~~~
+Python library for the Teleco / TMate cloud API.
+
+Quick start::
+
+    from teleco_daisy import TelecoDaisy
+
+    api = TelecoDaisy("user@example.com", "secret")
+    api.login()
+
+    for inst in api.get_installations():
+        online = api.is_installation_online(inst)
+        print(inst, "online:", online)
+
+        for room in api.get_rooms(inst):
+            print(" ", room)
+            for device in room.deviceList:
+                print("   ", device)
+"""
+
+from .client import TelecoDaisy
+from .devices import (
+    DaisyAwningCover,
+    DaisyCover,
+    DaisyDevice,
+    DaisyDeviceWithCommands,
+    DaisyHeater4CH,
+    DaisyLight,
+    DaisyRGBLight,
+    DaisyRoom,
+    DaisyRoomWithCommands,
+    DaisyRetractableSlatsCover,
+    DaisyShadeCover,
+    DaisySlatsCover,
+    DaisyWhite4LevelLight,
+)
+from .exceptions import AckError, ApiError, AuthError, CommandError, TelecoError
+from .models import (
+    ConfirmationUser,
+    DaisyInstallation,
+    FeedCommandResult,
+    InstallationCloud,
+    ScenarioCloud,
+    StatusItem,
+    TimerCloud,
+    TimerSetup,
+)
+
+__all__ = [
+    # Client
+    "TelecoDaisy",
+    # Devices
+    "DaisyDevice",
+    "DaisyDeviceWithCommands",
+    "DaisyRoom",
+    "DaisyRoomWithCommands",
+    "DaisyLight",
+    "DaisyRGBLight",
+    "DaisyWhite4LevelLight",
+    "DaisyCover",
+    "DaisySlatsCover",
+    "DaisyRetractableSlatsCover",
+    "DaisyShadeCover",
+    "DaisyAwningCover",
+    "DaisyHeater4CH",
+    # Models
+    "DaisyInstallation",
+    "InstallationCloud",
+    "ScenarioCloud",
+    "StatusItem",
+    "TimerCloud",
+    "TimerSetup",
+    "ConfirmationUser",
+    "FeedCommandResult",
+    # Exceptions
+    "TelecoError",
+    "AuthError",
+    "ApiError",
+    "CommandError",
+    "AckError",
+]
+
+__version__ = "0.2.2"

--- a/custom_components/teleco_daisy/_lib/client.py
+++ b/custom_components/teleco_daisy/_lib/client.py
@@ -1,0 +1,625 @@
+"""
+teleco_daisy.client
+~~~~~~~~~~~~~~~~~~~
+Main API client for the Teleco / TMate cloud service.
+
+Usage::
+
+    from teleco_daisy import TelecoDaisy
+
+    api = TelecoDaisy("user@example.com", "secret")
+    api.login()
+
+    for inst in api.get_installations():
+        print(inst)
+        for room in api.get_rooms(inst):
+            for device in room.deviceList:
+                print(" ", device)
+"""
+
+from __future__ import annotations
+
+import logging
+from time import sleep
+from typing import Any
+
+import requests
+
+from .devices import DaisyDevice, DaisyRoom, DaisyRoomWithCommands, create_device
+from .exceptions import AckError, ApiError, AuthError, CommandError
+from .models import (
+    ConfirmationUser,
+    DaisyInstallation,
+    FeedCommandResult,
+    InstallationCloud,
+    ScenarioCloud,
+    StatusItem,
+    TimerCloud,
+    TimerSetup,
+)
+
+log = logging.getLogger(__name__)
+
+BASE_URL = "https://tmate.telecoautomation.com/"
+_BASIC_USER = "teleco"
+_BASIC_PASS = "tmate20"
+
+
+class TelecoDaisy:
+    """
+    Synchronous client for the Teleco / TMate cloud API.
+
+    Parameters
+    ----------
+    email:    Account e-mail address.
+    password: Account password.
+    base_url: Override the default cloud endpoint (e.g. for staging).
+    timeout:  HTTP request timeout in seconds (default 15).
+    """
+
+    def __init__(
+        self,
+        email: str,
+        password: str,
+        base_url: str = BASE_URL,
+        timeout: int = 15,
+    ):
+        self.email = email
+        self.password = password
+        self.base_url = base_url.rstrip("/") + "/"
+        self.timeout = timeout
+
+        self._session = requests.Session()
+        self._session.auth = (_BASIC_USER, _BASIC_PASS)
+
+        self.id_account: int | None = None
+        self.id_session: str | None = None
+
+    # ------------------------------------------------------------------
+    # Internal HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _post(
+        self,
+        path: str,
+        body: dict | None = None,
+        *,
+        authenticated: bool = True,
+    ) -> dict | None:
+        """
+        POST to ``path`` (relative to base_url).
+
+        When *authenticated* is True the session/account tokens are merged
+        into the body.  Raises :class:`ApiError` on non-"S" codEsito.
+        Returns ``valRisultato`` (may be None for some endpoints).
+        """
+        payload: dict[str, Any] = {}
+        if authenticated:
+            payload["idSession"] = self.id_session
+            payload["idAccount"] = self.id_account
+        if body:
+            payload |= body
+
+        url = self.base_url + path
+        log.debug("POST %s  body=%s", url, payload)
+        resp = self._session.post(url, json=payload, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        log.debug("     → %s", data)
+
+        cod = data.get("codEsito")
+        if cod is not None and cod != "S":
+            raise ApiError(data)
+
+        return data.get("valRisultato")
+
+    def _tmate20_post(self, path: str, body: dict | None = None) -> dict:
+        """
+        POST to a tmate20 endpoint that returns raw JSON (no codEsito wrapper).
+        Always injects idSession.
+        """
+        payload: dict[str, Any] = {"idSession": self.id_session}
+        if body:
+            payload |= body
+
+        url = self.base_url + path
+        log.debug("POST %s  body=%s", url, payload)
+        resp = self._session.post(url, json=payload, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        log.debug("     → %s", data)
+        return data
+
+    # ------------------------------------------------------------------
+    # Account / auth
+    # ------------------------------------------------------------------
+
+    def login(self) -> None:
+        """
+        Authenticate and store session tokens.
+
+        Raises :class:`AuthError` if credentials are rejected.
+        """
+        try:
+            result = self._post(
+                "teleco/services/account-login",
+                {"email": self.email, "pwd": self.password},
+                authenticated=False,
+            )
+        except ApiError as exc:
+            raise AuthError("Login failed") from exc
+
+        self.id_account = result["idAccount"]
+        self.id_session = result["idSession"]
+        log.info("Logged in as account %d", self.id_account)
+
+    def logout(self) -> None:
+        """Invalidate the session on the server and clear local tokens."""
+        self._post("teleco/services/account-logout")
+        log.info("Logged out account %d", self.id_account)
+        self.id_account = None
+        self.id_session = None
+
+    def register(
+        self,
+        email: str,
+        password: str,
+        firstname: str,
+        lastname: str,
+        account_source: str = "daisy",
+        flg_advert: str = "N",
+    ) -> ConfirmationUser:
+        """
+        Create a new cloud account.
+
+        Returns a :class:`~teleco_daisy.models.ConfirmationUser` with the
+        new account id and e-mail confirmation details.
+        """
+        result = self._post(
+            "teleco/services/account-registration",
+            {
+                "email": email,
+                "pwd": password,
+                "firstname": firstname,
+                "lastname": lastname,
+                "accountSource": account_source,
+                "flgAdvert": flg_advert,
+                "flgBanner": "S",
+                "idApp": "DAISY",
+            },
+            authenticated=False,
+        )
+        return ConfirmationUser(**result)
+
+    def change_password(
+        self, pwd_old: str, pwd_new: str, id_account: int | None = None
+    ) -> None:
+        """Change the password for the currently logged-in account."""
+        self._post(
+            "teleco/services/change-password",
+            {
+                "idAccount": id_account or self.id_account,
+                "pwdOld": pwd_old,
+                "pwdNew": pwd_new,
+            },
+        )
+
+    def reset_password(self, email: str) -> None:
+        """Trigger a password-reset e-mail."""
+        self._post(
+            "teleco/services/reset-password",
+            {"email": email},
+            authenticated=False,
+        )
+
+    # ------------------------------------------------------------------
+    # Installations
+    # ------------------------------------------------------------------
+
+    def get_installations(self) -> list[DaisyInstallation]:
+        """Return all installations paired with this account."""
+        result = self._post("teleco/services/account-installation-list")
+        return [DaisyInstallation(**i) for i in result["installationList"]]
+
+    def pair_installation(
+        self,
+        inst_code: str,
+        inst_description: str,
+        installation_order: int = 0,
+        activetimer: str = "N",
+        weekend: str | None = None,
+        workdays: str | None = None,
+        firmware_version: str | None = None,
+    ) -> dict:
+        """
+        Pair a new installation (hub) with this account.
+
+        ``inst_code`` is the unique code printed on the hub.
+        Returns the raw ``valRisultato`` from the server.
+        """
+        return self._post(
+            "teleco/services/account-installation-pair",
+            {
+                "instCode": inst_code,
+                "instDescription": inst_description,
+                "installationOrder": installation_order,
+                "activetimer": activetimer,
+                "weekend": weekend,
+                "workdays": workdays,
+                "firmwareVersion": firmware_version,
+            },
+        )
+
+    def unpair_installation(self, installation: DaisyInstallation) -> None:
+        """Remove the association between this account and an installation."""
+        self._post(
+            "teleco/services/account-installation-unpair",
+            {"idInstallation": installation.idInstallation},
+        )
+
+    def setup_installation(
+        self,
+        installation: DaisyInstallation,
+        inst_description: str | None = None,
+        installation_order: int | None = None,
+        activetimer: str | None = None,
+        weekend: str | None = None,
+        workdays: str | None = None,
+        firmware_version: str | None = None,
+    ) -> InstallationCloud:
+        """
+        Update installation metadata.
+
+        Omitted parameters fall back to the values already on *installation*.
+        Returns the server's updated :class:`~teleco_daisy.models.InstallationCloud`.
+        """
+        result = self._post(
+            "teleco/services/installation-setup",
+            {
+                "idInstallation": installation.idInstallation,
+                "instCode": installation.instCode,
+                "instDescription": inst_description or installation.instDescription,
+                "installationOrder": (
+                    installation_order
+                    if installation_order is not None
+                    else installation.installationOrder
+                ),
+                "activetimer": activetimer or installation.activetimer,
+                "weekend": weekend or installation.weekend,
+                "workdays": workdays or installation.workdays,
+                "firmwareVersion": firmware_version or installation.firmwareVersion,
+            },
+        )
+        return InstallationCloud(**result)
+
+    def is_installation_online(self, installation: DaisyInstallation) -> bool:
+        """Return True if the hub is reachable (nodestatus endpoint)."""
+        result = self._tmate20_post(
+            "teleco/services/tmate20/nodestatus/",
+            {"idInstallation": installation.instCode},
+        )
+        return bool(result.get("nodeActive"))
+
+    # ------------------------------------------------------------------
+    # Rooms
+    # ------------------------------------------------------------------
+
+    def get_rooms(self, installation: DaisyInstallation) -> list[DaisyRoom]:
+        """
+        Return all rooms (with live device objects) for an installation.
+
+        Each device in the returned rooms has ``client`` and ``installation``
+        already populated so you can call ``.command()``, ``.update_state()`` etc.
+        """
+        result = self._post(
+            "teleco/services/room-list",
+            {"idInstallation": installation.idInstallation},
+        )
+        rooms: list[DaisyRoom] = []
+        for room in result["roomList"]:
+            devices = []
+            for raw_dev in room.get("deviceList", []):
+                raw_dev["client"] = self
+                raw_dev["installation"] = installation
+                devices.append(create_device(raw_dev))
+            rooms.append(DaisyRoom(**room | {"deviceList": devices}))
+        return rooms
+
+    def get_rooms_with_commands(
+        self, installation: DaisyInstallation
+    ) -> list[DaisyRoomWithCommands]:
+        """
+        Return rooms with command definitions (no live client references).
+        Useful for inspecting available commands per device.
+        """
+        result = self._post(
+            "teleco/services/room-configuration-list",
+            {"idInstallation": installation.idInstallation},
+        )
+        return [DaisyRoomWithCommands(**r) for r in result["roomList"]]
+
+    def setup_room(
+        self,
+        installation: DaisyInstallation,
+        id_installation_room: int,
+        room_description: str,
+        id_roomtype: int,
+        room_order: int,
+        device_list: list[dict] | None = None,
+    ) -> dict:
+        """Create or update a room. Returns the raw ``valRisultato``."""
+        return self._post(
+            "teleco/services/room-setup",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationRoom": id_installation_room,
+                "roomDescription": room_description,
+                "idRoomtype": id_roomtype,
+                "roomOrder": room_order,
+                "deviceList": device_list or [],
+            },
+        )
+
+    def delete_room(
+        self,
+        installation: DaisyInstallation,
+        id_installation_room: int,
+    ) -> None:
+        """Delete a room from an installation."""
+        self._post(
+            "teleco/services/room-delete",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationRoom": id_installation_room,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Device status
+    # ------------------------------------------------------------------
+
+    def status_device_list(
+        self, installation: DaisyInstallation, device: DaisyDevice
+    ) -> list[StatusItem]:
+        """Return the current status items for *device*."""
+        result = self._post(
+            "teleco/services/status-device-list",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationDevice": device.idInstallationDevice,
+            },
+        )
+        return [StatusItem(**x) for x in result.get("statusitemList", [])]
+
+    def get_command_device_list(
+        self,
+        installation: DaisyInstallation,
+        id_installation_device: int,
+    ) -> dict:
+        """Return the available commands for a specific device."""
+        return self._post(
+            "teleco/services/command-device-list",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationDevice": id_installation_device,
+            },
+        )
+
+    def setup_command_device(
+        self,
+        installation: DaisyInstallation,
+        id_installation_device: int,
+    ) -> dict:
+        """Trigger a command-device-setup (re-sync device commands)."""
+        return self._post(
+            "teleco/services/command-device-setup",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationDevice": id_installation_device,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Scenarios
+    # ------------------------------------------------------------------
+
+    def get_scenarios(self, installation: DaisyInstallation) -> list[ScenarioCloud]:
+        """Return all saved scenarios for an installation."""
+        result = self._post(
+            "teleco/services/scenario-list",
+            {"idInstallation": installation.idInstallation},
+        )
+        return [ScenarioCloud(**s) for s in result.get("scenarioList", [])]
+
+    def get_scenario_commands(
+        self,
+        installation: DaisyInstallation,
+        id_installation_scenario: int,
+    ) -> dict:
+        """Return the command list for a specific scenario."""
+        return self._post(
+            "teleco/services/command-scenario-list",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationScenario": id_installation_scenario,
+            },
+        )
+
+    def setup_scenario(
+        self,
+        installation: DaisyInstallation,
+        id_installation_scenario: int,
+        scenario_description: str,
+        scenario_order: int,
+        id_installation_room: int,
+        icon: int = 0,
+        command_list: list[dict] | None = None,
+    ) -> dict:
+        """
+        Create or update a scenario.
+
+        *command_list* is a list of dicts with keys
+        ``idInstallationDeviceCommand``, ``commandIndex``, ``commandParam``.
+        """
+        return self._post(
+            "teleco/services/scenario-setup",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationScenario": id_installation_scenario,
+                "scenarioDescription": scenario_description,
+                "scenarioOrder": scenario_order,
+                "idInstallationRoom": id_installation_room,
+                "icon": icon,
+                "commandList": command_list or [],
+            },
+        )
+
+    def delete_scenario(
+        self,
+        installation: DaisyInstallation,
+        id_installation_scenario: int,
+    ) -> None:
+        """Delete a scenario."""
+        self._post(
+            "teleco/services/scenario-delete",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationScenario": id_installation_scenario,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Timers
+    # ------------------------------------------------------------------
+
+    def get_timers(
+        self,
+        installation: DaisyInstallation,
+        id_installation_device: int,
+    ) -> TimerSetup:
+        """Return the timer configuration for a device."""
+        result = self._post(
+            "teleco/services/timer-device-list/",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationDevice": id_installation_device,
+            },
+        )
+        return TimerSetup(**result)
+
+    def setup_timers(
+        self,
+        installation: DaisyInstallation,
+        id_installation_device: int,
+        timer_list: list[dict],
+    ) -> TimerSetup:
+        """
+        Write a timer configuration for a device.
+
+        *timer_list* is a list of dicts corresponding to
+        :class:`~teleco_daisy.models.TimerCloud` fields.
+        """
+        result = self._post(
+            "teleco/services/timer-device-setup/",
+            {
+                "idInstallation": installation.idInstallation,
+                "idInstallationDevice": id_installation_device,
+                "timerList": timer_list,
+            },
+        )
+        return TimerSetup(**result)
+
+    # ------------------------------------------------------------------
+    # Feed commands / ack
+    # ------------------------------------------------------------------
+
+    def feed_the_commands(
+        self,
+        installation: DaisyInstallation,
+        commandsList: list[dict],
+        *,
+        ignore_ack: bool = False,
+    ) -> FeedCommandResult:
+        """
+        Send one or more raw commands to the hub.
+
+        Returns a :class:`~teleco_daisy.models.FeedCommandResult`.
+        Raises :class:`~teleco_daisy.exceptions.CommandError` on protocol errors.
+        """
+        res = self._tmate20_post(
+            "teleco/services/tmate20/feedthecommands/",
+            {
+                "commandsList": commandsList,
+                "idInstallation": installation.instCode,
+                "idScenario": 0,
+                "isScenario": False,
+            },
+        )
+        if res.get("MessageID") != "WS-000":
+            raise CommandError(f"Unexpected MessageID: {res}")
+
+        action_ref = res.get("ActionReference")
+        if ignore_ack:
+            return FeedCommandResult(success=None, action_reference=action_ref)
+
+        return self._poll_ack(installation, action_ref)
+
+    def run_scenario(
+        self,
+        installation: DaisyInstallation,
+        id_installation_scenario: int,
+        *,
+        ignore_ack: bool = False,
+    ) -> FeedCommandResult:
+        """Trigger a saved scenario on the hub."""
+        res = self._tmate20_post(
+            "teleco/services/tmate20/feedthecommands/",
+            {
+                "commandsList": [],
+                "idInstallation": installation.instCode,
+                "idScenario": id_installation_scenario,
+                "isScenario": True,
+            },
+        )
+        if res.get("MessageID") != "WS-000":
+            raise CommandError(f"Unexpected MessageID: {res}")
+
+        action_ref = res.get("ActionReference")
+        if ignore_ack:
+            return FeedCommandResult(success=None, action_reference=action_ref)
+
+        return self._poll_ack(installation, action_ref)
+
+    def _poll_ack(
+        self,
+        installation: DaisyInstallation,
+        action_reference: str,
+        *,
+        max_retries: int = 10,
+    ) -> FeedCommandResult:
+        """Poll getackcommand until the hub confirms or rejects execution."""
+        for _ in range(max_retries):
+            res = self._tmate20_post(
+                "teleco/services/tmate20/getackcommand/",
+                {
+                    "id": action_reference,
+                    "idInstallation": installation.instCode,
+                    "idSession": self.id_session,
+                },
+            )
+            msg_id = res.get("MessageID")
+            msg_text = res.get("MessageText")
+
+            if msg_id != "WS-300":
+                raise AckError(f"Unexpected MessageID in ack: {res}")
+
+            if msg_text == "RCV":
+                sleep(0.5)
+                continue
+            if msg_text == "PROC":
+                return FeedCommandResult(success=True, action_reference=action_reference)
+            return FeedCommandResult(
+                success=False, action_reference=action_reference, message=msg_text
+            )
+
+        raise AckError(f"Hub did not confirm command after {max_retries} retries")

--- a/custom_components/teleco_daisy/_lib/devices.py
+++ b/custom_components/teleco_daisy/_lib/devices.py
@@ -1,0 +1,425 @@
+"""
+teleco_daisy.devices
+~~~~~~~~~~~~~~~~~~~~
+Device classes and factory. No third-party dependencies.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from .models import DaisyInstallation, StatusItem
+
+if TYPE_CHECKING:
+    from .client import TelecoDaisy
+
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyBaseDevice:
+    activetimer: str
+    deviceCode: str
+    deviceIndex: int
+    deviceOrder: int
+    favorite: str
+    feedback: str
+    idDevicemodel: int
+    idDevicetype: int
+    idInstallationDevice: int
+    label: str
+    remoteControlCode: str
+    directOnly: str | None = None
+
+
+@dataclass
+class DaisyDevice(DaisyBaseDevice):
+    client: "TelecoDaisy" = field(repr=False, default=None)
+    installation: DaisyInstallation = field(repr=False, default=None)
+
+    def __str__(self) -> str:
+        return f'{self.__class__.__name__}("{self.label}")'
+
+    def __repr__(self) -> str:
+        return (
+            f'<{self.__class__.__name__} label="{self.label}" '
+            f'id={self.idInstallationDevice} '
+            f'type={self.idDevicetype} model={self.idDevicemodel}>'
+        )
+
+    def command(self, params: dict) -> dict:
+        return self.client.feed_the_commands(
+            installation=self.installation,
+            commandsList=[
+                {
+                    "deviceCode": str(self.deviceIndex),
+                    "idInstallationDevice": self.idInstallationDevice,
+                }
+                | params
+            ],
+        )
+
+    def update_state(self) -> list[StatusItem]:
+        return self.client.status_device_list(self.installation, self)
+
+
+# ---------------------------------------------------------------------------
+# Device with command definitions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DeviceCommand:
+    commandAction: str | None = None
+    commandCode: str | None = None
+    commandParam: str | None = None
+    deviceIndex: int | None = None
+    idDevicetypeCommandModel: int | None = None
+    idInstallationDeviceCommand: int | None = None
+    lowlevelCommand: str | None = None
+
+
+@dataclass
+class DaisyDeviceWithCommands(DaisyBaseDevice):
+    deviceCommandList: list[DeviceCommand] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return f'DaisyDeviceWithCommands("{self.label}")'
+
+
+# ---------------------------------------------------------------------------
+# Rooms
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyRoom:
+    idInstallationRoom: int
+    idRoomtype: int
+    roomDescription: str
+    roomOrder: int
+    deviceList: list[DaisyDevice] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return f'DaisyRoom("{self.roomDescription}" [{len(self.deviceList)} devices])'
+
+
+@dataclass
+class DaisyRoomWithCommands:
+    idInstallationRoom: int
+    idRoomtype: int
+    roomDescription: str
+    roomOrder: int
+    deviceList: list[DaisyDeviceWithCommands] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return f'DaisyRoomWithCommands("{self.roomDescription}")'
+
+
+# ---------------------------------------------------------------------------
+# Covers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyCover(DaisyDevice):
+    is_closed: bool | None = None
+    osc_map: dict = field(default_factory=dict)
+
+    def update_state(self) -> list[StatusItem]:
+        stati = super().update_state()
+        for s in stati:
+            if s.statusitemCode == "OPEN_CLOSE":
+                if s.statusValue == "CLOSE":
+                    self.is_closed = True
+                elif s.statusValue == "OPEN":
+                    self.is_closed = False
+                else:
+                    self.is_closed = None
+        return stati
+
+    def open_cover(self) -> dict:
+        return self._osc("open")
+
+    def stop_cover(self) -> dict:
+        return self._osc("stop")
+
+    def close_cover(self) -> dict:
+        return self._osc("close")
+
+    def _osc(self, action: str) -> dict:
+        return self.command({"commandAction": "OPEN_STOP_CLOSE"} | self.osc_map[action])
+
+
+@dataclass
+class DaisySlatsCover(DaisyCover):
+    position: int | None = None
+
+    def update_state(self) -> list[StatusItem]:
+        stati = super().update_state()
+        for s in stati:
+            if s.statusitemCode == "LEVEL":
+                self.position = int(s.statusValue)
+        return stati
+
+    def open_cover(self, percent: str | None = None) -> dict:
+        if percent is None or percent == "100":
+            return self._osc("open")
+        level_map = {
+            "33":  {"commandParam": "LEV2", "commandId": 97, "lowlevelCommand": "CH2"},
+            "66":  {"commandParam": "LEV3", "commandId": 98, "lowlevelCommand": "CH3"},
+            "100": {"commandParam": "LEV4", "commandId": 99, "lowlevelCommand": "CH4"},
+        }
+        return self.command({"commandAction": "LEVEL"} | level_map[percent])
+
+
+@dataclass
+class DaisyShadeCover(DaisyCover):
+    # For shades/screens, Teleco's "OPEN" means deployed (blocking sun) and
+    # "CLOSE" means retracted — the inverse of HA cover semantics where
+    # is_closed=True means the cover is blocking. Override both state reading
+    # and the osc_map keys so that HA "open" retracts and "close" deploys.
+    def update_state(self) -> list[StatusItem]:
+        stati = super().update_state()
+        for s in stati:
+            if s.statusitemCode == "OPEN_CLOSE":
+                if s.statusValue == "OPEN":
+                    self.is_closed = True   # deployed = HA closed
+                elif s.statusValue == "CLOSE":
+                    self.is_closed = False  # retracted = HA open
+        return stati
+
+
+@dataclass
+class DaisyAwningCover(DaisyCover):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Lights
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyLight(DaisyDevice):
+    is_on: bool | None = None
+    brightness: int | None = None
+
+    def update_state(self) -> list[StatusItem]:
+        stati = super().update_state()
+        for s in stati:
+            if s.statusitemCode == "POWER":
+                self.is_on = s.statusValue == "ON"
+        return stati
+
+    def _turn_on(self, extra: dict) -> dict:
+        return self.command({"commandAction": "POWER", "commandParam": "ON"} | extra)
+
+    def _turn_off(self, extra: dict) -> dict:
+        return self.command({"commandAction": "POWER", "commandParam": "OFF"} | extra)
+
+
+@dataclass
+class DaisyRGBLight(DaisyLight):
+    rgb: tuple | None = None
+
+    def update_state(self) -> list[StatusItem]:
+        stati = super().update_state()
+        for s in stati:
+            if s.statusitemCode == "COLOR":
+                v = s.statusValue
+                self.brightness = int(v[1:4])
+                self.rgb = (int(v[5:8]), int(v[9:12]), int(v[13:16]))
+        return stati
+
+    def set_rgb_and_brightness(self, rgb=None, brightness=None) -> dict:
+        brightness = brightness if brightness is not None else (self.brightness or 0)
+        if not 0 <= brightness <= 100:
+            raise ValueError("brightness must be 0–100")
+        rgb = rgb if rgb is not None else (self.rgb or (255, 255, 255))
+        if any(not 0 <= c <= 255 for c in rgb):
+            raise ValueError("RGB channels must be 0–255")
+        v = f"A{brightness:03d}R{rgb[0]:03d}G{rgb[1]:03d}B{rgb[2]:03d}"
+        return self.command({"commandAction": "COLOR", "commandId": 137,
+                             "commandParam": v, "lowlevelCommand": None})
+
+    def turn_on(self) -> dict:
+        return self._turn_on({"commandId": 138, "lowlevelCommand": None})
+
+    def turn_off(self) -> dict:
+        return self._turn_off({"commandId": 138, "lowlevelCommand": None})
+
+
+@dataclass
+class DaisyWhite4LevelLight(DaisyLight):
+    brightness_map: dict = field(default_factory=dict)
+
+    def update_state(self) -> list[StatusItem]:
+        stati = super().update_state()
+        for s in stati:
+            if s.statusitemCode == "POWER":
+                self.is_on = s.statusValue == "ON"
+            elif s.statusitemCode == "LEVEL":
+                self.brightness = {"25": 25, "50": 50, "75": 75, "100": 100}.get(
+                    s.statusValue, 50
+                )
+        return stati
+
+    def set_brightness(self, brightness: int) -> dict:
+        if not 0 <= brightness <= 100:
+            raise ValueError("brightness must be 0–100")
+        if brightness == 0:
+            return self.turn_off()
+        level = (25 if brightness <= 37 else
+                 50 if brightness <= 62 else
+                 75 if brightness <= 87 else 100)
+        return self.command({"commandAction": "LEVEL"} | self.brightness_map[level])
+
+    def turn_on(self) -> dict:
+        if self.idDevicetype == 21 and self.idDevicemodel == 17:
+            return self._turn_on({"commandId": 40, "lowlevelCommand": "CH1"})
+        return self._turn_on({"commandId": 146, "lowlevelCommand": "CH1"})
+
+    def turn_off(self) -> dict:
+        if self.idDevicetype == 21 and self.idDevicemodel == 17:
+            return self._turn_off({"commandId": 41, "lowlevelCommand": "CH8"})
+        return self._turn_off({"commandId": 147, "lowlevelCommand": "CH8"})
+
+
+# ---------------------------------------------------------------------------
+# Retractable slats (model 44, subId 1 — "RAS")
+# Command IDs are server-assigned and differ per device model, so they are
+# fetched from command-device-list on first use instead of being hardcoded.
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyRetractableSlatsCover(DaisySlatsCover):
+    _cmd_map: dict = field(default_factory=dict, init=False, repr=False)
+
+    def _load_commands(self) -> None:
+        result = self.client.get_command_device_list(
+            self.installation, self.idInstallationDevice
+        )
+        for c in result.get("commandList", []):
+            key = (c.get("commandAction", ""), c.get("commandParam", ""))
+            self._cmd_map[key] = {
+                "commandId": c.get("idDevicetypeCommandModel", 0),
+                "lowlevelCommand": c.get("lowlevelCommand", ""),
+            }
+
+    def _c(self, action: str, param: str) -> dict:
+        if not self._cmd_map:
+            self._load_commands()
+        return {"commandParam": param} | self._cmd_map.get((action, param), {})
+
+    def open_cover(self, percent: str | None = None) -> dict:
+        if percent is None or percent == "100":
+            return self.command({"commandAction": "OPEN_STOP_CLOSE"} | self._c("OPEN_STOP_CLOSE", "OPEN"))
+        lev = {"33": "LEV2", "66": "LEV3", "100": "LEV4"}[percent]
+        return self.command({"commandAction": "LEVEL"} | self._c("LEVEL", lev))
+
+    def stop_cover(self) -> dict:
+        return self.command({"commandAction": "OPEN_STOP_CLOSE"} | self._c("OPEN_STOP_CLOSE", "STOP"))
+
+    def close_cover(self) -> dict:
+        return self.command({"commandAction": "OPEN_STOP_CLOSE"} | self._c("OPEN_STOP_CLOSE", "CLOSE"))
+
+
+# ---------------------------------------------------------------------------
+# Heater
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyHeater4CH(DaisyDevice):
+    def turn_on(self) -> dict:
+        return self.command({"commandAction": "POWER", "commandParam": "ON",
+                             "lowlevelCommand": "CH1", "commandId": 58})
+
+    def turn_off(self) -> dict:
+        return self.command({"commandAction": "POWER", "commandParam": "OFF",
+                             "lowlevelCommand": "CH4", "commandId": 59})
+
+    def set_level(self, level: str) -> dict:
+        cmd = {
+            "50":  {"commandId": 60, "commandParam": "LEV2", "lowlevelCommand": "CH3"},
+            "75":  {"commandId": 61, "commandParam": "LEV3", "lowlevelCommand": "CH2"},
+            "100": {"commandId": 62, "commandParam": "LEV4", "lowlevelCommand": "CH1"},
+        }[level]
+        return self.command({"commandAction": "LEVEL"} | cmd)
+
+
+# ---------------------------------------------------------------------------
+# Shared base fields for create_device
+# ---------------------------------------------------------------------------
+
+_BASE_FIELDS = {
+    "activetimer", "deviceCode", "deviceIndex", "deviceOrder",
+    "favorite", "feedback", "idDevicemodel", "idDevicetype",
+    "idInstallationDevice", "label", "remoteControlCode", "directOnly",
+    "client", "installation",
+}
+
+def _base(raw: dict) -> dict:
+    return {k: v for k, v in raw.items() if k in _BASE_FIELDS}
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def create_device(raw: dict) -> DaisyDevice:
+    dt = raw.get("idDevicetype")
+    dm = raw.get("idDevicemodel")
+
+    if dt == 23 and dm == 32:
+        return DaisyRGBLight(**_base(raw))
+
+    if dt == 24 and dm == 27:
+        return DaisySlatsCover(**_base(raw), osc_map={
+            "open":  {"commandId": 94, "commandParam": "OPEN",  "lowlevelCommand": "CH4"},
+            "stop":  {"commandId": 95, "commandParam": "STOP",  "lowlevelCommand": "CH7"},
+            "close": {"commandId": 96, "commandParam": "CLOSE", "lowlevelCommand": "CH1"},
+        })
+
+    if dt == 24 and dm == 44:
+        return DaisyRetractableSlatsCover(**_base(raw))
+
+    if dt == 21 and dm == 34:
+        return DaisyWhite4LevelLight(**_base(raw), brightness_map={
+            25:  {"commandParam": "LEV1", "commandId": 141, "lowlevelCommand": "CH4"},
+            50:  {"commandParam": "LEV2", "commandId": 142, "lowlevelCommand": "CH3"},
+            75:  {"commandParam": "LEV3", "commandId": 143, "lowlevelCommand": "CH2"},
+            100: {"commandParam": "LEV4", "commandId": 144, "lowlevelCommand": "CH1"},
+        })
+
+    if dt == 21 and dm == 17:
+        return DaisyWhite4LevelLight(**_base(raw), brightness_map={
+            25:  {"commandParam": "LEV1", "commandId": 42,  "lowlevelCommand": "CH4"},
+            50:  {"commandParam": "LEV2", "commandId": 43,  "lowlevelCommand": "CH3"},
+            75:  {"commandParam": "LEV3", "commandId": 44,  "lowlevelCommand": "CH2"},
+            100: {"commandParam": "LEV4", "commandId": 45,  "lowlevelCommand": "CH1"},
+        })
+
+    if dt == 21 and dm == 20:
+        return DaisyHeater4CH(**_base(raw))
+
+    if dt == 22 and dm == 31:
+        return DaisyShadeCover(**_base(raw), osc_map={
+            "open":  {"commandId": 113, "commandParam": "CLOSE", "lowlevelCommand": "CH8"},
+            "stop":  {"commandId": 112, "commandParam": "STOP",  "lowlevelCommand": "CH7"},
+            "close": {"commandId": 111, "commandParam": "OPEN",  "lowlevelCommand": "CH5"},
+        })
+
+    if dt == 22 and dm == 25:
+        return DaisyShadeCover(**_base(raw), osc_map={
+            "open":  {"commandId": 77, "commandParam": "CLOSE", "lowlevelCommand": "CH8"},
+            "stop":  {"commandId": 76, "commandParam": "STOP",  "lowlevelCommand": "CH7"},
+            "close": {"commandId": 75, "commandParam": "OPEN",  "lowlevelCommand": "CH5"},
+        })
+
+    if dt == 22 and dm == 21:
+        return DaisyAwningCover(**_base(raw), osc_map={
+            "open":  {"commandId": 63, "commandParam": "OPEN",  "lowlevelCommand": "CH5"},
+            "stop":  {"commandId": 64, "commandParam": "STOP",  "lowlevelCommand": "CH7"},
+            "close": {"commandId": 65, "commandParam": "CLOSE", "lowlevelCommand": "CH8"},
+        })
+
+    return DaisyDevice(**_base(raw))

--- a/custom_components/teleco_daisy/_lib/exceptions.py
+++ b/custom_components/teleco_daisy/_lib/exceptions.py
@@ -1,0 +1,30 @@
+"""
+teleco_daisy.exceptions
+~~~~~~~~~~~~~~~~~~~~~~~
+Exception hierarchy for the Teleco Daisy library.
+"""
+
+
+class TelecoError(Exception):
+    """Base exception for all library errors."""
+
+
+class AuthError(TelecoError):
+    """Raised when login / credential errors occur."""
+
+
+class ApiError(TelecoError):
+    """Raised when the API returns codEsito != 'S'."""
+
+    def __init__(self, response: dict):
+        self.cod_esito = response.get("codEsito")
+        self.msg_esito = response.get("msgEsito", "")
+        super().__init__(f"[{self.cod_esito}] {self.msg_esito}")
+
+
+class CommandError(TelecoError):
+    """Raised when a device command fails (MessageID or ack error)."""
+
+
+class AckError(CommandError):
+    """Raised when the hub does not confirm command execution."""

--- a/custom_components/teleco_daisy/_lib/models.py
+++ b/custom_components/teleco_daisy/_lib/models.py
@@ -1,0 +1,179 @@
+"""
+teleco_daisy.models
+~~~~~~~~~~~~~~~~~~~
+Dataclass models mirroring the Java cloud model classes from the Teleco Daisy
+Android app (reverse-engineered from classes3.dex via JADX).
+Uses only stdlib dataclasses + requests — no third-party dependencies.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _from_dict(cls, d: dict):
+    """Construct a dataclass from a dict, ignoring unknown keys."""
+    import inspect
+    known = {f.name for f in cls.__dataclass_fields__.values()}
+    return cls(**{k: v for k, v in d.items() if k in known})
+
+
+# ---------------------------------------------------------------------------
+# Session / auth
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionCloud:
+    idSession: str
+    idAccount: int
+
+
+@dataclass
+class ConfirmationUser:
+    idAccount: int
+    email: str
+    firstname: str
+    lastname: str
+    confirmationcode: str | None = None
+    confirmationurl: str | None = None
+    registrationdate: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# Installations
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DaisyInstallation:
+    activetimer: str
+    firmwareVersion: str
+    idInstallation: int
+    idInstallationDevice: int
+    instCode: str
+    instDescription: str
+    installationOrder: int
+    latitude: float | None = None
+    longitude: float | None = None
+    weekend: str | None = None
+    workdays: str | None = None
+
+    def __str__(self) -> str:
+        return f'DaisyInstallation("{self.instDescription}" fw{self.firmwareVersion})'
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "DaisyInstallation":
+        return _from_dict(cls, d)
+
+
+@dataclass
+class InstallationCloud:
+    idInstallation: int
+    idAccount: int
+    instCode: str
+    instDescription: str
+    installationOrder: int
+    idInstallationDevice: int | None = None
+    idSession: str | None = None
+    activetimer: str | None = None
+    weekend: str | None = None
+    workdays: str | None = None
+    firmwareVersion: str | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "InstallationCloud":
+        return _from_dict(cls, d)
+
+
+# ---------------------------------------------------------------------------
+# Devices / status
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StatusItem:
+    idInstallationDeviceStatusitem: int
+    idDevicetypeStatusitemModel: int
+    statusitemCode: str
+    statusItem: str
+    statusValue: str
+    lowlevelStatusitem: str | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "StatusItem":
+        return _from_dict(cls, d)
+
+
+# ---------------------------------------------------------------------------
+# Timers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TimerCloud:
+    idInstallationDeviceTimer: int
+    idInstallationDeviceCommand: int
+    timerOrder: int
+    commandParam: str | None = None
+    timerActive: str | None = None
+    timerDate: str | None = None
+    timerDateExpire: str | None = None
+    giorni: str | None = None
+    albaTramonto: int | None = None
+    crepuscolare: str | None = None
+    crepuscolareOffset: int | None = None
+    info: str | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TimerCloud":
+        return _from_dict(cls, d)
+
+
+@dataclass
+class TimerSetup:
+    idAccount: int
+    idSession: str
+    idInstallation: int
+    idInstallationDevice: int
+    timerList: list[TimerCloud] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "TimerSetup":
+        timers = [TimerCloud.from_dict(t) for t in d.get("timerList", [])]
+        return cls(
+            idAccount=d["idAccount"],
+            idSession=d["idSession"],
+            idInstallation=d["idInstallation"],
+            idInstallationDevice=d["idInstallationDevice"],
+            timerList=timers,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ScenarioCloud:
+    idInstallationScenario: int
+    idInstallation: int
+    idAccount: int
+    scenarioDescription: str
+    scenarioOrder: int
+    idInstallationRoom: int | None = None
+    idInstallationDevice: int | None = None
+    idSession: str | None = None
+    icon: int | None = None
+    commandList: list[dict] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ScenarioCloud":
+        return _from_dict(cls, d)
+
+
+# ---------------------------------------------------------------------------
+# Feed result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FeedCommandResult:
+    success: bool | None = None
+    action_reference: str | None = None
+    message: str | None = None

--- a/custom_components/teleco_daisy/climate.py
+++ b/custom_components/teleco_daisy/climate.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from teleco_daisy import DaisyHeater4CH
+from ._lib import DaisyHeater4CH
 
 from .const import DOMAIN
 

--- a/custom_components/teleco_daisy/climate.py
+++ b/custom_components/teleco_daisy/climate.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
-from homeassistant.components.climate import ClimateEntity, ClimateEntityFeature
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -26,21 +30,21 @@ async def async_setup_entry(
 
 
 class TelecoDaisyClimateEntity(ClimateEntity):
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_supported_features = (
+        ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.PRESET_MODE
+    )
+    _attr_preset_modes = ["50", "75", "100"]
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
     def __init__(self, heater: DaisyHeater4CH) -> None:
         self._heater = heater
-
         self._attr_unique_id = str(heater.idInstallationDevice)
         self._attr_name = heater.label
-
-        self._attr_supported_features = (
-            ClimateEntityFeature.TURN_ON
-            | ClimateEntityFeature.TURN_OFF
-            | ClimateEntityFeature.PRESET_MODE
-        )
-        self.preset_modes = ["50", "75", "100"]
-        # FIXME This is a workaround for the fact that teleco_daisy does not
-        #  report the current preset mode
-        self._preset_mode = None
+        self._attr_hvac_mode = HVACMode.OFF
+        self._attr_preset_mode: str | None = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -50,18 +54,19 @@ class TelecoDaisyClimateEntity(ClimateEntity):
             manufacturer="Teleco Automation",
         )
 
-    def turn_on(self):
-        self._heater.turn_on()
+    def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        if hvac_mode == HVACMode.HEAT:
+            self._heater.turn_on()
+        else:
+            self._heater.turn_off()
+        self._attr_hvac_mode = hvac_mode
 
-    def turn_off(self):
-        self._heater.turn_off()
+    def turn_on(self) -> None:
+        self.set_hvac_mode(HVACMode.HEAT)
 
-    def set_preset_mode(self, preset_mode: Literal["50", "75", "100"]):
+    def turn_off(self) -> None:
+        self.set_hvac_mode(HVACMode.OFF)
+
+    def set_preset_mode(self, preset_mode: str) -> None:
         self._heater.set_level(preset_mode)
-        self._preset_mode = preset_mode
-
-    @property
-    def preset_mode(self) -> str | None:
-        # FIXME This is a workaround for the fact that teleco_daisy does not
-        #  report the current preset mode
-        return self._preset_mode
+        self._attr_preset_mode = preset_mode

--- a/custom_components/teleco_daisy/cover.py
+++ b/custom_components/teleco_daisy/cover.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from teleco_daisy import DaisyAwningCover, DaisyShadeCover, DaisySlatsCover
+from ._lib import DaisyAwningCover, DaisyShadeCover, DaisySlatsCover
 
 from .const import DOMAIN
 

--- a/custom_components/teleco_daisy/hub.py
+++ b/custom_components/teleco_daisy/hub.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import logging
+
 from homeassistant.core import HomeAssistant
 
+import teleco_daisy as _lib
 from teleco_daisy import DaisyCover, DaisyHeater4CH, DaisyLight, TelecoDaisy
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class DaisyHub(TelecoDaisy):
@@ -20,19 +25,65 @@ class DaisyHub(TelecoDaisy):
 
         self.online = True
 
+        _LOGGER.debug(
+            "DaisyHub created, teleco_daisy library version: %s",
+            getattr(_lib, "__version__", "unknown"),
+        )
+
     def fetch_entities(self):
         self.lights = []
         self.covers = []
         self.heaters = []
-        for installation in self.get_installations():
-            for room in self.get_rooms(installation):
+
+        _LOGGER.debug("fetch_entities: starting installation discovery")
+        installations = self.get_installations()
+        _LOGGER.debug("fetch_entities: found %d installation(s)", len(installations))
+
+        for installation in installations:
+            _LOGGER.debug("fetch_entities: processing installation %s", installation)
+
+            rooms = self.get_rooms(installation)
+            _LOGGER.debug(
+                "fetch_entities: installation %s has %d room(s)",
+                installation.instCode,
+                len(rooms),
+            )
+
+            for room in rooms:
+                _LOGGER.debug(
+                    "fetch_entities: room '%s' has %d device(s)",
+                    room.roomDescription,
+                    len(room.deviceList),
+                )
                 for device in room.deviceList:
+                    _LOGGER.debug(
+                        "fetch_entities: device '%s' type=%s model=%s -> %s",
+                        device.label,
+                        device.idDevicetype,
+                        device.idDevicemodel,
+                        type(device).__name__,
+                    )
                     if isinstance(device, DaisyLight):
-                        self.lights += [device]
+                        self.lights.append(device)
                     elif isinstance(device, DaisyCover):
-                        self.covers += [device]
+                        self.covers.append(device)
                     elif isinstance(device, DaisyHeater4CH):
-                        self.heaters += [device]
+                        self.heaters.append(device)
+                    else:
+                        _LOGGER.warning(
+                            "fetch_entities: unrecognised device '%s' "
+                            "(type=%s model=%s) — not added to any platform",
+                            device.label,
+                            device.idDevicetype,
+                            device.idDevicemodel,
+                        )
+
+        _LOGGER.debug(
+            "fetch_entities: complete — %d light(s), %d cover(s), %d heater(s)",
+            len(self.lights),
+            len(self.covers),
+            len(self.heaters),
+        )
 
     @property
     def hub_id(self) -> str:

--- a/custom_components/teleco_daisy/hub.py
+++ b/custom_components/teleco_daisy/hub.py
@@ -4,8 +4,8 @@ import logging
 
 from homeassistant.core import HomeAssistant
 
-import teleco_daisy as _lib
-from teleco_daisy import DaisyCover, DaisyHeater4CH, DaisyLight, TelecoDaisy
+from . import _lib
+from ._lib import DaisyCover, DaisyHeater4CH, DaisyLight, TelecoDaisy
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/teleco_daisy/hub.py
+++ b/custom_components/teleco_daisy/hub.py
@@ -24,8 +24,8 @@ class DaisyHub(TelecoDaisy):
         self.lights = []
         self.covers = []
         self.heaters = []
-        for installation in self.get_account_installation_list():
-            for room in self.get_room_list(installation):
+        for installation in self.get_installations():
+            for room in self.get_rooms(installation):
                 for device in room.deviceList:
                     if isinstance(device, DaisyLight):
                         self.lights += [device]

--- a/custom_components/teleco_daisy/light.py
+++ b/custom_components/teleco_daisy/light.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
-from teleco_daisy import DaisyRGBLight, DaisyWhite4LevelLight
+from ._lib import DaisyRGBLight, DaisyWhite4LevelLight
 
 from .const import DOMAIN
 

--- a/custom_components/teleco_daisy/manifest.json
+++ b/custom_components/teleco_daisy/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/andreasnuesslein/hass_teleco_daisy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/andreasnuesslein/hass_teleco_daisy/issues",
-  "requirements": ["teleco_daisy>=0.1.12.3"],
-  "version": "0.1.12.3"
+  "requirements": ["teleco_daisy>=0.2.0"],
+  "version": "0.2.0"
 }

--- a/custom_components/teleco_daisy/manifest.json
+++ b/custom_components/teleco_daisy/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/andreasnuesslein/hass_teleco_daisy",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/andreasnuesslein/hass_teleco_daisy/issues",
-  "requirements": ["teleco_daisy>=0.2.0"],
-  "version": "0.2.0"
+  "requirements": ["requests>=2.28", "pydantic>=2.0"],
+  "version": "0.2.3"
 }

--- a/custom_components/teleco_daisy/strings.json
+++ b/custom_components/teleco_daisy/strings.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "Teleco Daisy",
+                "data": {
+                    "username": "Email address",
+                    "password": "Password"
+                }
+            }
+        },
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 # ! REMEMBER the manifest.json
 dependencies = [
-    "teleco-daisy==0.1.12.3",
+    "teleco-daisy==0.2.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 # ! REMEMBER the manifest.json
 dependencies = [
-    "teleco-daisy==0.2.0",
+    "teleco-daisy==0.2.2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

- **Bundle `teleco_daisy` library (v0.2.2)** directly under `_lib/` — the library is not published on PyPI past v0.1.12.3, causing install failures on fresh HA instances. The component is now self-contained with only `requests` and `pydantic` as external deps.
- **Add climate platform** — registers `DaisyHeater4CH` entities with proper `HVACMode`, `preset_modes`, and `set_hvac_mode` support.
- **Fix hub API method names** — corrects `get_installations` and `get_rooms` call signatures that had drifted from the library.
- **Fix config flow 500 error** — adds missing `strings.json` which caused a server error when opening the integration in the HA UI.
- **Update README** with supported devices, installation instructions, and a changelog.

## Test plan

- [ ] Install integration on a fresh HA instance (no pre-installed `teleco_daisy` wheel) — should succeed without PyPI errors
- [ ] Config flow opens without a 500 error
- [ ] `DaisyHeater4CH` entities appear as climate entities with HVAC modes and presets
- [ ] Cover entities (shade, retractable slats) continue to work as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)